### PR TITLE
Fix for other player combat triggering false reel in messages.

### DIFF
--- a/Luminary_FishMe/FishMe.lua
+++ b/Luminary_FishMe/FishMe.lua
@@ -79,14 +79,16 @@ local function TempDisableAlerts()
     zo_callLater(function() ReEnableAlertS() end, 1500)
 end
 
-local function FishMeNow(bagId, slotId, isNewItem, itemSoundCategory, updateReason)
+local function FishMeNow(eventId, bagId, slotId, isNewItem, itemSoundCategory, updateReason)
+    if itemSoundCategory ~= ITEM_SOUND_CATEGORY_LURE then return end
+    if bagId ~= BAG_BACKPACK then return end
     if SavedVars.Enable_Reel_Alerts then -- allow user to disable reel in alerts.
         local action, name = GetGameCameraInteractableActionInfo()
         if action == GetString(SI_GAMECAMERAACTIONTYPE17) and name == SI.get(SI.FISHINGHOLE) then
             if not Config.tempDisableAlerts then
                 if Config.allowAlert then
                     if not SCENE_MANAGER:IsInUIMode() then
-                        if not itemSoundCategory then
+                        if not isNewItem then
                             CENTER_SCREEN_ANNOUNCE:AddMessage(0, CSA_EVENT_LARGE_TEXT, SOUNDS.BOOK_ACQUIRED, SI.get(SI.REELIN))
                             --d(SI.get(SI.REELIN))
                         end


### PR DESCRIPTION
Fix for bug reported in http://www.esoui.com/downloads/info187-Luminary-FishMe-Update6.html#cmnt43478
FishMeNow() was missing a parameter, eventId, which was throwing off the values for all the other parameters.  
After adding the eventId, the fix confirms that the bagId is correct, and that the item sound category is the one for a lure item.
